### PR TITLE
Cotel day 2

### DIFF
--- a/cotel/adventofcode.cabal
+++ b/cotel/adventofcode.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: d9b98dbf97cf69fd02ac323777b16691e2d72d82285f3b478105a033f44aaeb0
+-- hash: 759a5f60110d67976c2509c94bc32ca2859a3e8138239588b57f3402df52050e
 
 name:           adventofcode
 version:        0.1.0.0
@@ -29,6 +29,7 @@ library
   exposed-modules:
       Day0
       Day01
+      Day02
   other-modules:
       Paths_adventofcode
   hs-source-dirs:
@@ -60,6 +61,7 @@ test-suite day0-test
   main-is: Spec.hs
   other-modules:
       Day01Spec
+      Day02Spec
       Day0Spec
       Paths_adventofcode
   hs-source-dirs:

--- a/cotel/src/Day02.hs
+++ b/cotel/src/Day02.hs
@@ -24,10 +24,11 @@ tupleAppearances xs | 2 `elem` appearances && 3 `elem` appearances = (1, 1)
 checksum :: (Int, Int) -> Int
 checksum (x, y) = x * y
 
+instance Semigroup Int where
+    (<>) x y = x + y
+
 fullChecksum :: [String] -> Int
-fullChecksum xs = checksum $ foldl (\(a, b) (x, y) -> (a + x, b + y))
-                                   (0, 0)
-                                   (map tupleAppearances xs)
+fullChecksum xs = checksum $ foldl (<>) (0, 0) (map tupleAppearances xs)
 
 -- Part 2
 
@@ -44,5 +45,5 @@ commonLettersOfCorrectIds :: [String] -> String
 commonLettersOfCorrectIds xs = (head . filter differInOneLetter)
     [ fromJust mzs | x <- xs, y <- xs, let mzs = commonWords x y, isJust mzs ]
   where
-    wordLength        = (length . head) xs
+    wordLength = (length . head) xs
     differInOneLetter zs = wordLength - length zs == 1

--- a/cotel/src/Day02.hs
+++ b/cotel/src/Day02.hs
@@ -3,7 +3,7 @@ module Day02
     , tupleAppearances
     , fullChecksum
     , commonLettersOfCorrectIds
-    , commonWords
+    , commonLetters
     )
 where
 
@@ -32,8 +32,8 @@ fullChecksum xs = checksum $ foldl (<>) (0, 0) (map tupleAppearances xs)
 
 -- Part 2
 
-commonWords :: String -> String -> Maybe String
-commonWords xs ys = fmap reverse (go xs ys [] 0 0)
+commonLetters :: String -> String -> Maybe String
+commonLetters xs ys = fmap reverse (go xs ys [] 0 0)
   where
     go xs ys rs pos rep
         | rep > 1                    = Nothing
@@ -43,7 +43,7 @@ commonWords xs ys = fmap reverse (go xs ys [] 0 0)
 
 commonLettersOfCorrectIds :: [String] -> String
 commonLettersOfCorrectIds xs = (head . filter differInOneLetter)
-    [ fromJust mzs | x <- xs, y <- xs, let mzs = commonWords x y, isJust mzs ]
+    [ fromJust mzs | x <- xs, y <- xs, let mzs = commonLetters x y, isJust mzs ]
   where
     wordLength = (length . head) xs
     differInOneLetter zs = wordLength - length zs == 1

--- a/cotel/src/Day02.hs
+++ b/cotel/src/Day02.hs
@@ -1,0 +1,48 @@
+module Day02
+    ( checksum
+    , tupleAppearances
+    , fullChecksum
+    , commonLettersOfCorrectIds
+    , commonWords
+    )
+where
+
+import           Data.List                      ( elemIndices )
+import           Data.Maybe                     ( isJust
+                                                , fromJust
+                                                )
+
+-- Part 1
+
+tupleAppearances :: String -> (Int, Int)
+tupleAppearances xs | 2 `elem` appearances && 3 `elem` appearances = (1, 1)
+                    | 2 `elem` appearances = (1, 0)
+                    | 3 `elem` appearances = (0, 1)
+                    | otherwise            = (0, 0)
+    where appearances = [ length (elemIndices x xs) | x <- xs ]
+
+checksum :: (Int, Int) -> Int
+checksum (x, y) = x * y
+
+fullChecksum :: [String] -> Int
+fullChecksum xs = checksum $ foldl (\(a, b) (x, y) -> (a + x, b + y))
+                                   (0, 0)
+                                   (map tupleAppearances xs)
+
+-- Part 2
+
+commonWords :: String -> String -> Maybe String
+commonWords xs ys = fmap reverse (go xs ys [] 0 0)
+  where
+    go xs ys rs pos rep
+        | rep > 1                    = Nothing
+        | length xs <= pos           = Just rs
+        | (xs !! pos) == (ys !! pos) = go xs ys ((xs !! pos) : rs) (pos + 1) rep
+        | otherwise                  = go xs ys rs (pos + 1) (rep + 1)
+
+commonLettersOfCorrectIds :: [String] -> String
+commonLettersOfCorrectIds xs = (head . filter differInOneLetter)
+    [ fromJust mzs | x <- xs, y <- xs, let mzs = commonWords x y, isJust mzs ]
+  where
+    wordLength        = (length . head) xs
+    differInOneLetter zs = wordLength - length zs == 1

--- a/cotel/test/Day02Spec.hs
+++ b/cotel/test/Day02Spec.hs
@@ -1,0 +1,40 @@
+module Day02Spec where
+
+import Test.Hspec
+import Test.QuickCheck
+import Day02
+
+spec = describe "Day 02 tests" $ do
+    describe "Part 1" $ do
+        describe "checksum should multiplicate elements of a tuple" $
+            it "(4, 4) should return 16" $
+                checksum (4, 4) `shouldBe` 16
+
+        describe "tupleAppearances" $ do
+            it "should return (1, 0) if there is a word appearing twice" $
+                tupleAppearances "abcdee" `shouldBe` (1, 0)
+
+            it "should return (0, 1) if there is a word appearing thrice" $
+                tupleAppearances "abcccdbb" `shouldBe` (0, 1)
+
+            it "should return (1, 1) if there both conditions meet" $
+                tupleAppearances "bababc" `shouldBe` (1, 1)
+
+            it "should return (0, 0) if no condition is met" $
+                tupleAppearances "abcdef" `shouldBe` (0, 0)
+
+        describe "fullChecksum" $
+            it "example checksum should be 12" $
+                fullChecksum ["abcdef", "bababc", "abbcde", "abcccd", "aabcdd", "abcdee", "ababab"] `shouldBe` 12
+
+    describe "Part 2" $ do
+        describe "commonWords" $ do
+            it "should return Nothing from abcde and abxyc" $
+                commonWords "abcde" "abxyc" `shouldBe` Nothing
+            
+            it "should return Just fgij from fghij and fguij" $
+                commonWords "fghij" "fguij" `shouldBe` Just "fgij"
+
+        describe "commonLettersOfCorrectIds" $
+            it "example commonLetters are fgij" $
+                commonLettersOfCorrectIds ["abcde", "fghij", "klmno", "pqrst", "fguij", "axcye", "wvxyz"] `shouldBe` "fgij"

--- a/cotel/test/Day02Spec.hs
+++ b/cotel/test/Day02Spec.hs
@@ -28,12 +28,12 @@ spec = describe "Day 02 tests" $ do
                 fullChecksum ["abcdef", "bababc", "abbcde", "abcccd", "aabcdd", "abcdee", "ababab"] `shouldBe` 12
 
     describe "Part 2" $ do
-        describe "commonWords" $ do
+        describe "commonLetters" $ do
             it "should return Nothing from abcde and abxyc" $
-                commonWords "abcde" "abxyc" `shouldBe` Nothing
+                commonLetters "abcde" "abxyc" `shouldBe` Nothing
             
             it "should return Just fgij from fghij and fguij" $
-                commonWords "fghij" "fguij" `shouldBe` Just "fgij"
+                commonLetters "fghij" "fguij" `shouldBe` Just "fgij"
 
         describe "commonLettersOfCorrectIds" $
             it "example commonLetters are fgij" $


### PR DESCRIPTION
Well, today I'm not as happy as yesterday but at least I solved it 🤷‍♂️ 

## Part 1

On the first part we have to calculate a checksum from a list of box ids. For every id we have to calculate a tuple with the following rules:

* (1,0) if a letter appears twice exactly
* (0, 1) if a letter appears three times exactly
* (1, 1) if a letter appears twice and a different letter appears thrice.
* (0, 0) otherwise.

```haskell
tupleAppearances :: String -> (Int, Int)
tupleAppearances xs | 2 `elem` appearances && 3 `elem` appearances = (1, 1)
                    | 2 `elem` appearances = (1, 0)
                    | 3 `elem` appearances = (0, 1)
                    | otherwise            = (0, 0)
    where appearances = [ length (elemIndices x xs) | x <- xs ]
```

(God bless pattern matching 😄)

Once we have a tuple for each id we have to sum them and then multiply the left element with the right.

```haskell
checksum :: (Int, Int) -> Int
checksum (x, y) = x * y

instance Semigroup Int where
    (<>) x y = x + y

fullChecksum :: [String] -> Int
fullChecksum xs = checksum $ foldl (<>) (0, 0) (map tupleAppearances xs)
```

I am defining a Semigroup instance for telling Haskell how I want to combine tuples of ints. This is shorter than defining a lambda like `(\(x,y) (a,b) -> (x + a, y + b))`.

![image](https://user-images.githubusercontent.com/9035239/49339105-1d47b500-f62d-11e8-807c-1cb62202c290.png)


## Part 2

This code is infamous. I'm sure there is a relation between the first part and this problem but I didn't manage to see it. Tests helped a lot here though.

This time, given a list of ids, we have to find two which only differ in one letter, the rest of them should be equal in the same positions (ie. "fguij" and "fghij"). Once we find them we have to return a string containing the common letters.

I've defined a recursive function for getting the common letters out of two strings allowing just one difference:

```haskell
commonLetters :: String -> String -> Maybe String
commonLetters xs ys = fmap reverse (go xs ys [] 0 0)
  where
    go xs ys rs pos rep
        | rep > 1                    = Nothing
        | length xs <= pos           = Just rs
        | (xs !! pos) == (ys !! pos) = go xs ys ((xs !! pos) : rs) (pos + 1) rep
        | otherwise                  = go xs ys rs (pos + 1) (rep + 1)
```

Now I have to execute this method for every string against every other string of the list. I will only take those which return a `Just` and then I will only take those strings which have `length - 1` compared to one of the original strings. This is because I am comparing a string with itself so their `commonLetters` are all.

```haskell
commonLettersOfCorrectIds :: [String] -> String
commonLettersOfCorrectIds xs = (head . filter differInOneLetter)
    [ fromJust mzs | x <- xs, y <- xs, let mzs = commonLetters x y, isJust mzs ]
  where
    wordLength = (length . head) xs
    differInOneLetter zs = wordLength - length zs == 1
```

![image](https://user-images.githubusercontent.com/9035239/49339202-b3c8a600-f62e-11e8-988f-c983d67be7c2.png)

